### PR TITLE
add quotes for password in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ blnet:
 - Grouping has to be manually accomplished.
 - Digital outputs of the UVR1611 can be controlled via created switch entities.
 - __Turning a switch off or on overrides the `AUTO` configuration and sets the switch to `HAND` until it is turned back to `AUTO` manually.__
-- if the password is all numbers and start with a leading zero quotes are required, otherwise the leading 0 will be ommitted and the password is incorrect
+- If the password is all numbers and start with a leading zero, add quotes around the password. If the quotes are omitted, the leading 0 is discarded and the password will not be correct.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ blnet:
   # Poll interval in seconds (Optional, Default: 360)
   scan_interval: 360
   # Expert access password of the web-interface (Optional, Default: None)
-  password: 1234
+  password: "1234"
   # Enable BLNet-Direct access (Broken, Optional, Default: False)
   use_ta: false
   # BLNet-Direct port (Optional, Default: 4000)
@@ -56,6 +56,7 @@ blnet:
 - Grouping has to be manually accomplished.
 - Digital outputs of the UVR1611 can be controlled via created switch entities.
 - __Turning a switch off or on overrides the `AUTO` configuration and sets the switch to `HAND` until it is turned back to `AUTO` manually.__
+- if the password is all numbers and start with a leading zero quotes are required, otherwise the leading 0 will be ommitted and the password is incorrect
 
 ## Contributions
 


### PR DESCRIPTION
I have an all digit password with a leading 0, which was omitted by python as a leading 0 of a digit, making my password incorrect and the integration not working properly. I added a warning and quotes for the example. Proved in my instance to work correctly.